### PR TITLE
allow apoc procedures to run

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,8 @@ services:
   neo4j:
     build: .
     environment:
-      NEO4J_AUTH: ${NEO4J_AUTH:-none}
+      - "NEO4J_AUTH=none"
+      - "NEO4J_dbms_security_procedures_unrestricted=apoc.*"
     expose:
       - 7474
       - 7473


### PR DESCRIPTION
`call apoc.meta.graph` was throwing errors around permissions. The notice here said to add this environment flag https://neo4j-contrib.github.io/neo4j-apoc-procedures/index32.html